### PR TITLE
support underscores in symbols when converting between ruby hash syntax versions

### DIFF
--- a/init-ruby-mode.el
+++ b/init-ruby-mode.el
@@ -119,9 +119,8 @@
     (goto-char beg)
     (cond
      ((save-excursion (search-forward "=>" end t))
-      (replace-regexp ":\\(\\w+\\) +=> +" "\\1: " nil beg end))
+      (replace-regexp ":\\([a-zA-Z0-9_]+\\) +=> +" "\\1: " nil beg end))
      ((save-excursion (re-search-forward "\\w+:" end t))
-      (replace-regexp "\\(\\w+\\):\\( *\\(?:\"\\(?:\\\"\\|[^\"]\\)*\"\\|'\\(?:\\'\\|[^']\\)*'\\|\\w+([^)]*)\\|[^,]+\\)\\)" ":\\1 =>\\2" nil beg end)))))
-
+      (replace-regexp "\\([a-zA-Z0-9_]+\\):\\( *\\(?:\"\\(?:\\\"\\|[^\"]\\)*\"\\|'\\(?:\\'\\|[^']\\)*'\\|[a-zA-Z0-9_]+([^)]*)\\|[^,]+\\)\\)" ":\\1 =>\\2" nil beg end)))))
 
 (provide 'init-ruby-mode)


### PR DESCRIPTION
I have no idea why ruby-mode doesn't consider _ a word character.

Maybe there's a better way to fix this, but it works (tm).
