### PR TITLE
Update init-osx-keys.el for terminal F10

### DIFF
--- a/init-osx-keys.el
+++ b/init-osx-keys.el
@@ -2,6 +2,7 @@
   (setq mac-command-modifier 'meta)
   (setq mac-option-modifier 'none)
   (setq default-input-method "MacOSX")
+  (define-key key-translation-map "\e[21~" [f10])
   ;; Make mouse wheel / trackpad scrolling less jerky
   (setq mouse-wheel-scroll-amount '(0.001))
   (when *is-cocoa-emacs*


### PR DESCRIPTION
F10 in terminal should work now.  See Issue #72
