### PR TITLE
Only use anzu if Emacs version >= 24

### DIFF
--- a/lisp/init-isearch.el
+++ b/lisp/init-isearch.el
@@ -1,10 +1,10 @@
 ;; Show number of matches while searching
-(require-package 'anzu)
-(global-anzu-mode t)
-(diminish 'anzu-mode)
-(global-set-key [remap query-replace-regexp] 'anzu-query-replace-regexp)
-(global-set-key [remap query-replace] 'anzu-query-replace)
-
+(when (>= emacs-major-version 24)
+  (require-package 'anzu)
+  (global-anzu-mode t)
+  (diminish 'anzu-mode)
+  (global-set-key [remap query-replace-regexp] 'anzu-query-replace-regexp)
+  (global-set-key [remap query-replace] 'anzu-query-replace))
 
 ;; Activate occur easily inside isearch
 (define-key isearch-mode-map (kbd "C-o") 'isearch-occur)


### PR DESCRIPTION
anzu breaks init-isearch.el in Emacs 23

See https://github.com/syohex/emacs-anzu/commit/8e92765ab7ecb821017b4f03fa8678acc4720e53#diff-fea2dd3403e76294136c80b7bee7dbd8
