### PR TITLE
add directory eshell to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ site-lisp/package/
 /emms/
 /.smex-items
 /image-dired/
+/eshell


### PR DESCRIPTION
add directory eshell to .gitignore, making the git status clean for eshell users.
