### PR TITLE
Fix sanityinc/add-subdirs-to-load-path to only add subdirs

### DIFF
--- a/lisp/init-site-lisp.el
+++ b/lisp/init-site-lisp.el
@@ -7,9 +7,9 @@
     (progn
       (setq load-path
             (append
-             (loop for dir in (directory-files parent-dir)
-                   unless (string-match "^\\." dir)
-                   collecting (expand-file-name dir))
+             (remove-if-not
+              (lambda (dir) (file-directory-p dir))
+              (directory-files (expand-file-name parent-dir) t "^[^\\.]"))
              load-path)))))
 
 (sanityinc/add-subdirs-to-load-path


### PR DESCRIPTION
I noticed that `~/.emacs.d/site-lisp/README` was in my load-path, this should fix it so `sanityinc/add-subdirs-to-load-path` only adds subdirs of `~/.emacs.d/site-lisp` instead of all non-hidden files and subdirs.

I tested the fix on Linux using GNU Emacs built from the official git sources on 2014-11-04.
