### PR TITLE
Diminish interactive-haskell-mode correctly

### DIFF
--- a/lisp/init-haskell.el
+++ b/lisp/init-haskell.el
@@ -61,7 +61,7 @@ been saved."
 
 ;; Interaction
 
-(after-load 'haskell-process
+(after-load 'haskell
   (diminish 'interactive-haskell-mode " IntHS"))
 
 (add-auto-mode 'haskell-mode "\\.ghci\\'")


### PR DESCRIPTION
`interactive-haskell-mode` is defined in haskell.el and without this change I'm getting `File mode specification error: (error "interactive-haskell-mode is not currently registered as a minor mode")` whenever I open a .hs file.
