### PR TITLE
Added ccl to the slime-lisp-implementations

### DIFF
--- a/lisp/init-common-lisp.el
+++ b/lisp/init-common-lisp.el
@@ -11,7 +11,10 @@
                  '(sbcl ("sbcl") :coding-system utf-8-unix)))
   (when (executable-find "lisp")
     (add-to-list 'slime-lisp-implementations
-                 '(cmucl ("lisp") :coding-system iso-latin-1-unix))))
+                 '(cmucl ("lisp") :coding-system iso-latin-1-unix)))
+  (when (executable-find "ccl")
+    (add-to-list 'slime-lisp-implementations
+                 '(ccl ("ccl") :coding-system utf-8-unix))))
 
 ;; From http://bc.tech.coop/blog/070515.html
 (defun lispdoc ()


### PR DESCRIPTION
Clozure Common Lisp (ccl) is one of the most used lisp compilers around, as much as sbcl. It's probably nice to have it loaded as the others already listed.