### PR TITLE
Ignore stuffs like session.102e27...010076 for git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.emacs.desktop
 /auto-save-list
 /.session
+/seesion.*
 /custom.el
 *.elc
 CVS


### PR DESCRIPTION
I find that sometimes git status will be no clean due to a session file like session.102e27...010076 been created in ./emacs.d.