### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.emacs.desktop
 /auto-save-list
 /.session
+/session.*
 /custom.el
 *.elc
 CVS


### PR DESCRIPTION
Now I get that why files like session.108b0f4a9a8472bb99145330775785387000000022540061 are created in ~/.emacs.d. 
Look at [this](http://emacs.stackexchange.com/questions/12679/session-files-in-emacs-d-folder)
And in my 3.13.0-67-generic Ubuntu, if I run` $ emacs` or `$ emacsclient -c` and shutdown my Ubuntu without close emacs, these session file would be created.