### PR TITLE
Replace removed Cider hook

### DIFF
--- a/lisp/init-clojure-cider.el
+++ b/lisp/init-clojure-cider.el
@@ -4,7 +4,7 @@
   (setq nrepl-popup-stacktraces nil)
 
   (after-load 'cider
-    (add-hook 'cider-mode-hook 'cider-turn-on-eldoc-mode)
+    (add-hook 'cider-mode-hook 'eldoc-mode)
     (add-hook 'cider-repl-mode-hook 'subword-mode)
     (add-hook 'cider-repl-mode-hook 'paredit-mode)
 


### PR DESCRIPTION
`cider-turn-on-eldoc-mode` was removed from Cider in version 9, which was released June 2015. [Changelog](https://github.com/clojure-emacs/cider/blob/master/CHANGELOG.md#changes-6)

The substitution is just to use `'eldoc-mode` now.