### PR TITLE
Flycheck rubocop issue on rvm based environment

### DIFF
--- a/init.el
+++ b/init.el
@@ -59,6 +59,7 @@
 (require 'init-grep)
 (require 'init-uniquify)
 (require 'init-ibuffer)
+(require 'init-rvm)
 (require 'init-flycheck)
 
 (require 'init-recentf)

--- a/lisp/init-rvm.el
+++ b/lisp/init-rvm.el
@@ -1,0 +1,6 @@
+(require-package 'rvm)
+
+(require 'rvm)
+(rvm-use-default) ;; use rvm's default ruby for the current Emacs session
+
+(provide 'init-rvm)


### PR DESCRIPTION
If you use `rvm` and try to open .rb file the next error in *Messages* buffer appears:
```
Suspicious state from syntax checker ruby-rubocop: Checker ruby-rubocop returned non-zero exit code 1, but no errors from output: /Users/green/.rvm/rubies/ruby-2.2.4/lib/ruby/site_ruby/2.2.0/rubygems/dependency.rb:315:in `to_specs': Could not find 'rubocop' (>= 0) among 14 total gem(s) (Gem::LoadError)
Checked in 'GEM_PATH=/Users/green/.gem/ruby/2.2.0:/Users/green/.rvm/rubies/ruby-2.2.4/lib/ruby/gems/2.2.0', execute `gem env` for more information
	from /Users/green/.rvm/rubies/ruby-2.2.4/lib/ruby/site_ruby/2.2.0/rubygems/dependency.rb:324:in `to_spec'
	from /Users/green/.rvm/rubies/ruby-2.2.4/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_gem.rb:64:in `gem'
	from /Users/green/.rvm/gems/ruby-2.2.4/bin/rubocop:22:in `<main>'
	from /Users/green/.rvm/gems/ruby-2.2.4/bin/ruby_executable_hooks:15:in `eval'
	from /Users/green/.rvm/gems/ruby-2.2.4/bin/ruby_executable_hooks:15:in `<main>'
```
As a result, the syntax checking does not work for ruby on `rvm`-based environments.
To get this solved I added `rvm` package in dependencies and loaded before `init-flycheck`

P.S. not sure if this does not produce errors on a non-`rvm` environment, I have no possibility to check this