### PR TITLE
Fix TRAMP issues about ssh+sudo

### DIFF
--- a/lisp/init-projectile.el
+++ b/lisp/init-projectile.el
@@ -1,5 +1,6 @@
 (when (maybe-require-package 'projectile)
-  (add-hook 'after-init-hook 'projectile-global-mode)
+  (add-hook 'text-mode-hook 'projectile-mode)
+  (add-hook 'prog-mode-hook 'projectile-mode)
 
   ;; The following code means you get a menu if you hit "C-c p" and wait
   (after-load 'guide-key


### PR DESCRIPTION
Use tramp to access remote server, when it need password. That hangs on 'Sending password'

I found problem was about `projectile-global-mode ` via https://github.com/bbatsov/prelude/issues/594