### PR TITLE
fix "Wrong number of arguments"

### DIFF
--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -284,7 +284,7 @@ typical word processor."
   (interactive)
   (save-excursion
     (beginning-of-line 0)
-    (org-remove-empty-drawer-at "LOGBOOK" (point))))
+    (org-remove-empty-drawer-at (point))))
 
 (after-load 'org-clock
   (add-hook 'org-clock-out-hook 'sanityinc/remove-empty-drawer-on-clock-out 'append))


### PR DESCRIPTION
when I press "C-c C-x C-o" to run org-clock-out, an error shows:

save-excursion: Wrong number of arguments: #[(pos) "rÂ!
 Ã! pq~bÄ Å	!Æ>= ÇÈ	\"?= ÇÉ	\"ÇÊ	\"bËÌxÌy`|," [pos drawer markerp marker-buffer org-element-at-point org-element-type (drawer property-drawer) org-element-property :contents-begin :begin ...] 4 ("/Users/emuio/.emacs.d/elpa/org-20160829/org.elc" . 463859)], 2