### PR TITLE
Change the way to determine whether to load “init-osx-keys.el”

### DIFF
--- a/init.el
+++ b/init.el
@@ -51,7 +51,8 @@
 (require 'init-frame-hooks)
 (require 'init-xterm)
 (require 'init-themes)
-(require 'init-osx-keys)
+(when *is-a-mac*
+  (require 'init-osx-keys))
 (require 'init-gui-frames)
 (require 'init-dired)
 (require 'init-isearch)

--- a/lisp/init-osx-keys.el
+++ b/lisp/init-osx-keys.el
@@ -1,21 +1,19 @@
-(when *is-a-mac*
-  (setq mac-command-modifier 'meta)
-  (setq mac-option-modifier 'none)
-  (setq-default default-input-method "MacOSX")
-  ;; Make mouse wheel / trackpad scrolling less jerky
-  (setq mouse-wheel-scroll-amount '(1
-                                    ((shift) . 5)
-                                    ((control))))
-  (dolist (multiple '("" "double-" "triple-"))
-    (dolist (direction '("right" "left"))
-      (global-set-key (read-kbd-macro (concat "<" multiple "wheel-" direction ">")) 'ignore)))
-  (global-set-key (kbd "M-`") 'ns-next-frame)
-  (global-set-key (kbd "M-h") 'ns-do-hide-emacs)
-  (global-set-key (kbd "M-˙") 'ns-do-hide-others)
-  (after-load 'nxml-mode
-    (define-key nxml-mode-map (kbd "M-h") nil))
-  (global-set-key (kbd "M-ˍ") 'ns-do-hide-others) ;; what describe-key reports for cmd-option-h
-  )
+(setq mac-command-modifier 'meta)
+(setq mac-option-modifier 'none)
+(setq-default default-input-method "MacOSX")
+;; Make mouse wheel / trackpad scrolling less jerky
+(setq mouse-wheel-scroll-amount '(1
+                                  ((shift) . 5)
+                                  ((control))))
+(dolist (multiple '("" "double-" "triple-"))
+  (dolist (direction '("right" "left"))
+    (global-set-key (read-kbd-macro (concat "<" multiple "wheel-" direction ">")) 'ignore)))
+(global-set-key (kbd "M-`") 'ns-next-frame)
+(global-set-key (kbd "M-h") 'ns-do-hide-emacs)
+(global-set-key (kbd "M-˙") 'ns-do-hide-others)
+(after-load 'nxml-mode
+  (define-key nxml-mode-map (kbd "M-h") nil))
+(global-set-key (kbd "M-ˍ") 'ns-do-hide-others) ;; what describe-key reports for cmd-option-h
 
 
 (provide 'init-osx-keys)


### PR DESCRIPTION
I transferred the code to determine whether to load "init-osx-keys.el" to init.el.

Although this is useless,
But I would like to hear your opinion to determine whether I want to do it myself.
Would you like to give me some guidance?
Thanks.