### PR TITLE
Change the function of the judgment Emacs version

### DIFF
--- a/init.el
+++ b/init.el
@@ -3,7 +3,7 @@
 ;;; a number of other files.
 
 (let ((minver "24.1"))
-  (when (version<= emacs-version minver)
+  (when (version< emacs-version minver)
     (error "Your Emacs is too old -- this config requires v%s or higher" minver)))
 (when (version<= emacs-version "24.4")
   (message "Your Emacs is old, and some functionality in this config will be disabled. Please upgrade if possible."))


### PR DESCRIPTION
Whell, Sorry to take your time again.
Your code is this: 
```emacs-lisp
(let ((minver "24.1"))
  (when (version<= emacs-version minver)
    (error "Your Emacs is too old -- this config requires v%s or higher" minver)))
```

I don't understand that, "<=" mean. If you don't want to support a version, you should probably use "<" .

Now so, if my Emacs version is 24.1, doesn't it become "**error, and"require it"**"?

