### PR TITLE
Make Directory Local Variables conform to standard specifications

### DIFF
--- a/lisp/.dir-locals.el
+++ b/lisp/.dir-locals.el
@@ -1,1 +1,5 @@
-((emacs-lisp-mode . ((no-byte-compile t))))
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((emacs-lisp-mode
+  (no-byte-compile . t)))


### PR DESCRIPTION
Your `~/.emacs.d/lisp/.dir-locals.el` seems to be written manually, the result is that every time I want to edit your files, will pop up "unsafe" prompt box.
![virtualbox_arch linux_17_07_2017_10_15_03](https://user-images.githubusercontent.com/26828933/28253821-07b4e9ae-6ada-11e7-87f1-e2fd04800b92.png)

If you are deliberately doing so, Please forgive my rudeness.

Thank you.