### PR TITLE
Make "completion-cycle-threshold" to nil

### DIFF
--- a/lisp/init-company.el
+++ b/lisp/init-company.el
@@ -4,7 +4,7 @@
 (setq tab-always-indent 'complete)
 (add-to-list 'completion-styles 'initials t)
 ;; Stop completion-at-point from popping up completion buffers so eagerly
-(setq completion-cycle-threshold 5)
+(setq completion-cycle-threshold nil)
 
 
 (when (maybe-require-package 'company)


### PR DESCRIPTION
Hello, and sorry for taking your time.

I found that after setting this value to nil, the `company` would be faster.

I think that after having the `company`, it is not necessary to show the auto-completion result on the minibuffer.
Moreover, we have "company-capf" is not it?

Please forgive my rudeness.

Thanks.
 