### PR TITLE
Remove defunct '(provide 'init)' in init.el

### DIFF
--- a/init.el
+++ b/init.el
@@ -164,9 +164,6 @@
 (when (maybe-require-package 'uptimes)
   (add-hook 'after-init-hook (lambda () (require 'uptimes))))
 
-
-(provide 'init)
-
 ;; Local Variables:
 ;; coding: utf-8
 ;; no-byte-compile: t


### PR DESCRIPTION
Hello:
I did not find any other files `require` the 'init.el'.

So I don't know why this code is still useful ...And it also triggered a error report of syntax check(flycheck) for false positives  of `defconst`