### PR TITLE
Improved "Make sure ivy-mode is enabled"

### DIFF
--- a/lisp/init-ivy.el
+++ b/lisp/init-ivy.el
@@ -1,5 +1,6 @@
 ;;; -*- lexical-binding: t -*-
 (when (maybe-require-package 'ivy)
+  (add-hook 'after-init-hook 'ivy-mode)
   (after-load 'ivy
     (setq-default ivy-use-virtual-buffers t
                   ivy-virtual-abbreviate 'fullpath
@@ -17,8 +18,7 @@
     (define-key ivy-minibuffer-map (kbd "<up>") #'ivy-previous-line-or-history)
 
     (when (maybe-require-package 'diminish)
-      (diminish 'ivy-mode))
-    (add-hook 'after-init-hook 'ivy-mode))
+      (diminish 'ivy-mode)))
 
   (defun sanityinc/enable-ivy-flx-matching ()
     "Make `ivy' matching work more like IDO."


### PR DESCRIPTION
Hello:

I think putting the code within `after-load` does not really make sure that ivy-mode is enabled.

A practical example:
If I removed `~/.emacs.d/` and re-download your configuration, `ivy-switch-buffer` will not be enabled after the first startup. 
And no key binding, unless `counsel-M-x`, `counsel-find-file`.
I must manually enable `ivy-switch-buffer` with` M-x ivy-switch-buffer`

This is an example image:
after <kbd>C-x b</kbd>

<img width="1280" alt="1" src="https://user-images.githubusercontent.com/26828933/30245459-e232a546-960c-11e7-8aed-67e55b9bb94c.png">


This is an example image of improved:
after<kbd>C-x b</kbd>

<img width="1280" alt="2" src="https://user-images.githubusercontent.com/26828933/30245461-efcf35fc-960c-11e7-8281-209d3fe93c38.png">


Sorry for my poor English.