### PR TITLE
Resolve global keymap clash between dash-at-point & md/duplicate-up

### DIFF
--- a/lisp/init-editing-utils.el
+++ b/lisp/init-editing-utils.el
@@ -201,7 +201,7 @@
 (global-set-key [M-S-down] 'md/move-lines-down)
 
 (global-set-key (kbd "C-c d") 'md/duplicate-down)
-(global-set-key (kbd "C-c D") 'md/duplicate-up)
+(global-set-key (kbd "C-c u") 'md/duplicate-up)
 
 ;;----------------------------------------------------------------------------
 ;; Fix backward-up-list to understand quotes, see http://bit.ly/h7mdIL


### PR DESCRIPTION
Hey Steve! Hope all is well with you.

Thought you might like to merge this into your config, it's a tiny change that resolves a keybinding clash between `dash-at-point` and `md/duplicate-up`.

I chose to change the keybinding for `md/duplicate-up` to `C-c u` and leave `dash-at-point` as `C-c D` because that's what I'm used to 😛 .

Cheers,

Kieran