### PR TITLE
Remove defunct config for vc-darcs

### DIFF
--- a/lisp/init-darcs.el
+++ b/lisp/init-darcs.el
@@ -7,12 +7,6 @@
 (autoload 'vc-darcs-find-file-hook "vc-darcs")
 (add-hook 'find-file-hooks 'vc-darcs-find-file-hook)
 
-(after-load 'vc-darcs
-  ;; This variable was removed in an Emacs 25.x snapshot, but vc-darcs
-  ;; hasn't been fixed accordingly
-  (unless (boundp 'vc-disable-async-diff)
-    (setq vc-disable-async-diff nil)))
-
 (setq darcsum-whatsnew-switches "-l")
 
 (provide 'init-darcs)


### PR DESCRIPTION
Hello:

The author of vc-darcs seems to have fixed this bug.
 In short, after I remove the code to fix it, I did not see anything wrong with that variable.