### PR TITLE
Add missing "(after-load 'company)" for init-elm.el

### DIFF
--- a/lisp/init-elm.el
+++ b/lisp/init-elm.el
@@ -2,8 +2,9 @@
   (setq-default elm-format-on-save t)
   (after-load 'elm-mode
     (diminish 'elm-indent-mode)
-    (add-hook 'elm-mode-hook
-              (lambda () (sanityinc/local-push-company-backend 'company-elm)))
+    (after-load 'company
+      (add-hook 'elm-mode-hook
+                (lambda () (sanityinc/local-push-company-backend 'company-elm))))
     (when (executable-find "elm-format")
       (setq-default elm-format-on-save t)))
   (when (maybe-require-package 'flycheck-elm)


### PR DESCRIPTION
Hello:

Please forgive me for the stupid mistake in my last PR. And my poor English

In my observation, in some extreme cases `after-load` ensures that `company-elm` is correctly pushed into `company-backends`, and to ensure that work.

environment:
```
GNU Emacs 25.3.1 (x86_64-pc-linux-gnu, GTK+ Version 3.22.19) of 2017-09-17
Arch Linux x86_64 kernel-4.14.3
elm-2.5.8
```

Thanks.