### PR TITLE
Remove duplicate added code for add disable-mouse

### DIFF
--- a/lisp/init-editing-utils.el
+++ b/lisp/init-editing-utils.el
@@ -315,8 +315,5 @@ With arg N, insert N newlines."
 (after-load 'guide-key
   (diminish 'guide-key-mode))
 
-
-(require-package 'disable-mouse)
-
 
 (provide 'init-editing-utils)


### PR DESCRIPTION
Hello:

I saw your commit: [Add (but don't enable) disable-mouse](https://github.com/purcell/emacs.d/commit/29fe120cb2005f889dce40df60919d89ea9e3bd7)

However, this code is already in line 69 of: `lisp/init-gui-frames.el`.
Link: [init-gui-frames.el: line 69](https://github.com/purcell/emacs.d/blob/86adc49d280633d2e83e52e1e9c302ecbeac3666/lisp/init-gui-frames.el#L69)