### PR TITLE
Fixed typo for init-ruby-mode.el

### DIFF
--- a/lisp/init-ruby-mode.el
+++ b/lisp/init-ruby-mode.el
@@ -57,7 +57,7 @@
   (after-load 'ruby-mode
     (add-hook 'ruby-mode-hook 'robe-mode))
   (after-load 'company
-    (dolist (hook '(ruby-mode-hook inf-ruby-mode-hook html-erb-mode-hook haml-mode))
+    (dolist (hook '(ruby-mode-hook inf-ruby-mode-hook html-erb-mode-hook haml-mode-hook))
       (add-hook hook
                 (lambda () (sanityinc/local-push-company-backend 'company-robe))))))
 


### PR DESCRIPTION
Hello:

There is no `-hook` after `haml-mode`, causing `company-robe` to not start under haml-node.

I don't know why you did not add, but now, with `-hook` the hook works.

Thanks, and sorry for my poor English.