### PR TITLE
Drop defunct workaround for slime

### DIFF
--- a/lisp/init-slime.el
+++ b/lisp/init-slime.el
@@ -1,9 +1,4 @@
 (require-package 'slime)
-;; package.el compiles the contrib subdir, but the compilation order
-;; causes problems, so we remove the .elc files there. See
-;; http://lists.common-lisp.net/pipermail/slime-devel/2012-February/018470.html
-(mapc #'delete-file
-      (file-expand-wildcards (concat user-emacs-directory "elpa/slime-2*/contrib/*.elc")))
 
 (require-package 'hippie-expand-slime)
 (maybe-require-package 'slime-company)


### PR DESCRIPTION
Hello:

The current `slime` is completely normal. The error no longer occurs.
Tested on:
```
Emacs Version: GNU Emacs 25.3.1 (x86_64-pc-linux-gnu, GTK+ Version 3.22.26) of 2017-12-05
SLIME Version: 20180111.429
SBCL Version: SBCL 1.4.0
```


Thank you.