### PR TITLE
Test against Emacs 26.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - EVM_EMACS=emacs-25.1-travis
   - EVM_EMACS=emacs-25.2-travis
   - EVM_EMACS=emacs-25.3-travis
+  - EVM_EMACS=emacs-26.1-travis
   #- EVM_EMACS=emacs-git-snapshot-travis
 
 matrix:


### PR DESCRIPTION
The Emacs Version Manager (EVM) now includes Emacs 26.1.