### PR TITLE
Use define-key instead of outdated projectile-keymap-prefix

### DIFF
--- a/lisp/init-projectile.el
+++ b/lisp/init-projectile.el
@@ -1,10 +1,10 @@
 (when (maybe-require-package 'projectile)
   (add-hook 'after-init-hook 'projectile-mode)
 
-  (setq projectile-keymap-prefix (kbd "C-c C-p"))
-
-  ;; Shorter modeline
   (after-load 'projectile
+    (define-key projectile-mode-map (kbd "C-c C-p") 'projectile-command-map)
+
+    ;; Shorter modeline
     (setq-default
      projectile-mode-line
      '(:eval


### PR DESCRIPTION
Hello：
See https://github.com/bbatsov/projectile/blob/9c6e9813abec6e067c659e9107bf356086a95e04/projectile.el#L156 
and https://github.com/bbatsov/projectile/commit/9c6e9813abec6e067c659e9107bf356086a95e04
This variable is also obsolete as projectile removes the default shortcuts.

This  change has another advantage... If the users use `which-key`, they will see the correct `projectile-command-map` instead of `prefix`. But `guide-key` doesn't have this problem, so it doesn't seem to be an advantage...

Thanks.