### PR TITLE
Improve javascript configuration

### DIFF
--- a/lisp/init-javascript.el
+++ b/lisp/init-javascript.el
@@ -40,8 +40,7 @@
 
   (add-hook 'js2-mode-hook (lambda () (setq mode-name "JS2")))
 
-  (after-load 'js2-mode
-    (js2-imenu-extras-setup)))
+  (js2-imenu-extras-setup))
 
 ;; js-mode
 (setq-default js-indent-level preferred-javascript-indent-level)

--- a/lisp/init-javascript.el
+++ b/lisp/init-javascript.el
@@ -25,8 +25,7 @@
 ;; js2-mode
 
 ;; Change some defaults: customize them to override
-(setq-default js2-basic-offset 2
-              js2-bounce-indent-p nil)
+(setq-default js2-bounce-indent-p nil)
 (after-load 'js2-mode
   ;; Disable js2 mode's syntax error highlighting by default...
   (setq-default js2-mode-show-parse-errors nil


### PR DESCRIPTION
Hello:

This PR contains two changes:
+ Drop js2-basic-offset setting

Because it is an alias for js-indent-level

https://github.com/mooz/js2-mode/blob/2ed3cc070c7819556c9c89826b0f5c4629b104ef/js2-mode.el#L102

+ Remove duplicate code

You seem to have an `(after-load 'js2-mode)` nested inside `(after-load 'js2-mode)`.

Thanks.