### PR TITLE
Set gc-cons-threshold to normal-gc-cons-threshold in emacs-startup-hook

### DIFF
--- a/init.el
+++ b/init.el
@@ -22,7 +22,7 @@
 (let ((normal-gc-cons-threshold (* 20 1024 1024))
       (init-gc-cons-threshold (* 128 1024 1024)))
   (setq gc-cons-threshold init-gc-cons-threshold)
-  (add-hook 'after-init-hook
+  (add-hook 'emacs-startup-hook
             (lambda () (setq gc-cons-threshold normal-gc-cons-threshold))))
 
 ;;----------------------------------------------------------------------------


### PR DESCRIPTION
Hello

This change can slightly reduce the initialization time. And I think adjusting `gc-cons-threshold` should be something to do after startup.

Thanks.