### PR TITLE
Remove duplicate org-archive-mark-done setting

### DIFF
--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -9,7 +9,6 @@
 ;; Various preferences
 (setq org-log-done t
       org-edit-timestamp-down-means-later t
-      org-archive-mark-done nil
       org-hide-emphasis-markers t
       org-catch-invisible-edits 'show
       org-export-coding-system 'utf-8


### PR DESCRIPTION
Hello

You are already set up `org-archive-mark-down` in [init-org.el#Line 323](https://github.com/purcell/emacs.d/blob/a3d5c76d8406e93892617a774e821376d80e45c7/lisp/init-org.el#L323).

Thanks.