### PR TITLE
Install helm-dash package when not on a mac for Dash docsets usage

### DIFF
--- a/lisp/init-dash.el
+++ b/lisp/init-dash.el
@@ -14,7 +14,13 @@
   (when (sanityinc/dash-installed-p)
     (require-package 'dash-at-point)))
 
+(when (and (not *is-a-mac*) (not (package-installed-p 'helm-dash)))
+  (require-package 'helm-dash))
+
 (when (package-installed-p 'dash-at-point)
   (global-set-key (kbd "C-c D") 'dash-at-point))
+
+(when (package-installed-p 'helm-dash)
+  (global-set-key (kbd "C-c D") 'helm-dash-at-point))
 
 (provide 'init-dash)


### PR DESCRIPTION
On linux based OS I have been using the `helm-dash` emacs package to read Dash docsets within emacs. The `helm-dash-at-point` function helps to find some doc offline in a similar fashion than the current `dash-at-point` for Mac (I guess as I've never tried that later option :) ).
