### PR TITLE
Kill all local variables when disable prose-mode

### DIFF
--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -89,6 +89,7 @@ typical word processor."
     (kill-local-variable 'truncate-lines)
     (kill-local-variable 'word-wrap)
     (kill-local-variable 'cursor-type)
+    (kill-local-variable 'blink-cursor-interval)
     (kill-local-variable 'show-trailing-whitespace)
     (kill-local-variable 'line-spacing)
     (kill-local-variable 'electric-pair-mode)


### PR DESCRIPTION
Hello:

It seems that value of `blink-cursor-interval` does not back to the original value after disable prose-mode.

Thanks.