### PR TITLE
Remove defunct sanityinc/disable-indent-guide

### DIFF
--- a/lisp/init-lisp.el
+++ b/lisp/init-lisp.el
@@ -126,14 +126,9 @@
   "Run `check-parens' when the current buffer is saved."
   (add-hook 'after-save-hook #'check-parens nil t))
 
-(defun sanityinc/disable-indent-guide ()
-  (when (bound-and-true-p indent-guide-mode)
-    (indent-guide-mode -1)))
-
 (defvar sanityinc/lispy-modes-hook
   '(enable-paredit-mode
     turn-on-eldoc-mode
-    sanityinc/disable-indent-guide
     sanityinc/enable-check-parens-on-save)
   "Hook run in all Lisp modes.")
 


### PR DESCRIPTION
Hello:

This configuration seems to no longer use indent-guide.

Thanks.

BTW: I recently found that there is not very good indent-guide plugin in Emacs.

Another point to ask is... **Why is the name of the hook lispy**?