### PR TITLE
Use elm-test-runner instead of elm-test

### DIFF
--- a/lisp/init-elm.el
+++ b/lisp/init-elm.el
@@ -6,7 +6,7 @@
               (lambda () (sanityinc/local-push-company-backend 'company-elm)))
     (when (executable-find "elm-format")
       (setq-default elm-format-on-save t)))
-  (maybe-require-package 'elm-test)
+  (maybe-require-package 'elm-test-runner)
   (when (maybe-require-package 'flycheck-elm)
     (after-load 'elm-mode
       (flycheck-elm-setup))))


### PR DESCRIPTION
Hello:

Because`elm-test` is moved to `elm-test-runner`. See https://github.com/juanedi/elm-test-el/blob/master/README.md

Now in MELPA (at least in the mirror of [emacs-china](https://elpa.emacs-china.org)) you can't find `elm-test` anymore.

Thanks.