### PR TITLE
Set shorter projectile modeline correctly

### DIFF
--- a/lisp/init-projectile.el
+++ b/lisp/init-projectile.el
@@ -1,11 +1,11 @@
 (when (maybe-require-package 'projectile)
   (add-hook 'after-init-hook 'projectile-mode)
 
-  (after-load 'projectile
-    (define-key projectile-mode-map (kbd "C-c C-p") 'projectile-command-map)
+  ;; Shorter modeline
+  (setq-default projectile-mode-line-lighter " Proj")
 
-    ;; Shorter modeline
-    (setq-default projectile-mode-line-lighter " Proj"))
+  (after-load 'projectile
+    (define-key projectile-mode-map (kbd "C-c C-p") 'projectile-command-map))
 
   (maybe-require-package 'ibuffer-projectile))
 


### PR DESCRIPTION
Hello

See bbatsov/projectile#1288

Putting this setting in `after-load` will cause the non-file buffers and remote buffers to not display the set modeline lighter correctly.