### PR TITLE
Use projectile-mode-line-prefix to set projectile mode line

### DIFF
--- a/lisp/init-projectile.el
+++ b/lisp/init-projectile.el
@@ -2,7 +2,7 @@
   (add-hook 'after-init-hook 'projectile-mode)
 
   ;; Shorter modeline
-  (setq-default projectile-mode-line-lighter " Proj")
+  (setq-default projectile-mode-line-prefix " Proj")
 
   (after-load 'projectile
     (define-key projectile-mode-map (kbd "C-c C-p") 'projectile-command-map))


### PR DESCRIPTION
See https://github.com/bbatsov/projectile/commit/19943eb85ff4cb30466568b0d357c22d398e8cf8

`projectile-mode-line-lighter` is obsolete (that is, it is defined as an obsolete variable in the latest version), and continued use will cause problem mentioned in #621 (That is, `" Projectile"` will be displayed in non-file buffers and remote buffers instead of `" Proj"`).

I have been paying attention to the mode-line changes of `projectile` recently. Because this is caused by my issue.
If the inconvenience to you, I'm sorry.

BTW, why do you use so many `setq-default` instead of `setq`?

Thanks.