### PR TITLE
No longer ignore files that don't exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ CVS
 .*.lock
 /tramp
 /TODO
-/anything-c-adaptive-history
 /.org-id-locations
 cookies
 /newsticker

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ CVS
 /.org-id-locations
 cookies
 /newsticker
-/ac-comphist.dat
 \#*
 /elpa
 /elpa-*


### PR DESCRIPTION
Hello:

This configuration doesn't use `auto-complete` and `anything` now.

BTW: I found that your .gitignore should indeed clean up... For example, /swank will not be generated in your current configuration.

Thanks.