### PR TITLE
Drop redundant predicate code for dash-at-point

### DIFF
--- a/lisp/init-dash.el
+++ b/lisp/init-dash.el
@@ -11,10 +11,8 @@
 
 (when (and *is-a-mac* (not (package-installed-p 'dash-at-point)))
   (message "Checking whether Dash is installed")
-  (when (sanityinc/dash-installed-p)
-    (require-package 'dash-at-point)))
-
-(when (package-installed-p 'dash-at-point)
-  (global-set-key (kbd "C-c D") 'dash-at-point))
+  (when (and (sanityinc/dash-installed-p)
+             (maybe-require-package 'dash-at-point))
+    (global-set-key (kbd "C-c D") 'dash-at-point)))
 
 (provide 'init-dash)


### PR DESCRIPTION
Hello:

The current code will determine if "dash-at-point" is installed, regardless of whether the `dash-at-point` installation condition is met. I think this will make unnecessary judgments on OSs that never install `dash-at-point` (such as Linux).

Thank you and sorry for my poor English.