### PR TITLE
Remove non-existing hippie-expand item for elisp

### DIFF
--- a/lisp/init-lisp.el
+++ b/lisp/init-lisp.el
@@ -80,8 +80,7 @@
   "Locally set `hippie-expand' completion functions for use with Emacs Lisp."
   (make-local-variable 'hippie-expand-try-functions-list)
   (add-to-list 'hippie-expand-try-functions-list 'try-complete-lisp-symbol t)
-  (add-to-list 'hippie-expand-try-functions-list 'try-complete-lisp-symbol-partially t)
-  (add-to-list 'hippie-expand-try-functions-list 'my/try-complete-lisp-symbol-without-namespace t))
+  (add-to-list 'hippie-expand-try-functions-list 'try-complete-lisp-symbol-partially t))
 
 
 ;; ----------------------------------------------------------------------------


### PR DESCRIPTION
Hello:

`my/try-complete-lisp-symbol-without-namespace` has been removed.

Thanks.