### PR TITLE
Unset key "M-s" for tagedit to avoid conflicting with Emacs default bindings

### DIFF
--- a/lisp/init-html.el
+++ b/lisp/init-html.el
@@ -2,6 +2,7 @@
 (after-load 'sgml-mode
   (tagedit-add-paredit-like-keybindings)
   (define-key tagedit-mode-map (kbd "M-?") nil)
+  (define-key tagedit-mode-map (kbd "M-s") nil)
   (add-hook 'sgml-mode-hook (lambda () (tagedit-mode 1))))
 
 (add-auto-mode 'html-mode "\\.\\(jsp\\|tmpl\\)\\'")


### PR DESCRIPTION
Hello:


I found that `sanityinc/swiper-at-point` (<kbd>M-s /</kbd>) can't be used when writing HTML...

Thanks.