### PR TITLE
Fix wrong number of arguments for sanityinc/save-compilation-buffer

### DIFF
--- a/lisp/init-compile.el
+++ b/lisp/init-compile.el
@@ -24,7 +24,7 @@
   "The last buffer in which compilation took place.")
 
 (after-load 'compile
-  (defun sanityinc/save-compilation-buffer ()
+  (defun sanityinc/save-compilation-buffer (&rest _)
     "Save the compilation buffer to find it later."
     (setq sanityinc/last-compilation-buffer next-error-last-buffer))
   (advice-add 'compilation-start :after 'sanityinc/save-compilation-buffer)


### PR DESCRIPTION
Hello:

I found that under your latest code, the following error message will be generated after compilation:
```
(wrong-number-of-arguments (lambda nil "Save the compilation buffer to find it later." (setq sanityinc/last-compilation-buffer next-error-last-buffer)) 3)
...
```

Thanks.