### PR TITLE
Drop more unnecessary css-mode-hook references

### DIFF
--- a/lisp/init-editing-utils.el
+++ b/lisp/init-editing-utils.el
@@ -98,7 +98,7 @@
 
 
 (when (maybe-require-package 'symbol-overlay)
-  (dolist (hook '(prog-mode-hook html-mode-hook css-mode-hook yaml-mode-hook conf-mode-hook))
+  (dolist (hook '(prog-mode-hook html-mode-hook yaml-mode-hook conf-mode-hook))
     (add-hook hook 'symbol-overlay-mode))
   (after-load 'symbol-overlay
     (diminish 'symbol-overlay-mode)


### PR DESCRIPTION
Hello

See https://github.com/purcell/emacs.d/commit/71045816d420b345bc74de1d8467e1179b8c0fa8

So there is no need to quote css-mode-hook separately here.

Thanks.