### PR TITLE
Update ivy-initial-inputs-alist settings

### DIFF
--- a/lisp/init-ivy.el
+++ b/lisp/init-ivy.el
@@ -9,7 +9,7 @@
                   ivy-magic-tilde nil
                   ivy-dynamic-exhibit-delay-ms 150
                   ivy-initial-inputs-alist
-                  '((man . "^")
+                  '((Man-completion-table . "^")
                     (woman . "^")))
 
     ;; IDO-style directory navigation


### PR DESCRIPTION
Hello:

I found the ivy-initial-input for `man` is wrong, so make this change.

Thanks.