### PR TITLE
Improve init-ruby.el

### DIFF
--- a/lisp/init-ruby.el
+++ b/lisp/init-ruby.el
@@ -35,9 +35,8 @@
 (require-package 'ruby-compilation)
 
 (after-load 'ruby-mode
-  (let ((m ruby-mode-map))
-    (define-key m [S-f7] 'ruby-compilation-this-buffer)
-    (define-key m [f7] 'ruby-compilation-this-test)))
+  (define-key ruby-mode-map [S-f7] 'ruby-compilation-this-buffer)
+  (define-key ruby-mode-map [f7] 'ruby-compilation-this-test))
 
 (after-load 'ruby-compilation
   (defalias 'rake 'ruby-compilation-rake))
@@ -81,11 +80,10 @@
   (add-hook (derived-mode-hook-name mode) (lambda () (require 'mmm-erb)))
   (mmm-add-mode-ext-class mode "\\.erb\\'" 'erb))
 
-(let ((html-erb-modes '(html-mode html-erb-mode nxml-mode)))
-  (dolist (mode html-erb-modes)
-    (sanityinc/set-up-mode-for-erb mode)
-    (mmm-add-mode-ext-class mode "\\.r?html\\(\\.erb\\)?\\'" 'html-js)
-    (mmm-add-mode-ext-class mode "\\.r?html\\(\\.erb\\)?\\'" 'html-css)))
+(dolist (mode '(html-mode html-erb-mode nxml-mode))
+  (sanityinc/set-up-mode-for-erb mode)
+  (mmm-add-mode-ext-class mode "\\.r?html\\(\\.erb\\)?\\'" 'html-js)
+  (mmm-add-mode-ext-class mode "\\.r?html\\(\\.erb\\)?\\'" 'html-css))
 
 (mapc 'sanityinc/set-up-mode-for-erb
       '(coffee-mode js-mode js2-mode js3-mode markdown-mode textile-mode))

--- a/lisp/init-ruby.el
+++ b/lisp/init-ruby.el
@@ -1,5 +1,4 @@
 ;;; Basic ruby setup
-(require-package 'ruby-mode)
 (require-package 'ruby-hash-syntax)
 
 (add-auto-mode 'ruby-mode

--- a/lisp/init-ruby.el
+++ b/lisp/init-ruby.el
@@ -119,7 +119,7 @@
 ;;          :delimiter-mode nil)))
 ;;      (mmm-add-mode-ext-class 'ruby-mode "\\.rb\\'" 'ruby-heredoc-sql)))
 
-;(add-to-list 'mmm-set-file-name-for-modes 'ruby-mode)
+;; (add-to-list 'mmm-set-file-name-for-modes 'ruby-mode)
 
 
 


### PR DESCRIPTION
Hello:

This change improves `init-ruby.el`:

**Remove unnecessary let bindings** :
These two let bindings seem unnecessary.
`m` seems to be because there was a lot of code here, but now there are only two lines left.

And for `html-erb-modes`, I don't know what it is for. But I don't think that using a direct list will reduce readability.

**Use comments beginning with two semicolons**:
Comments beginning with a single semicolon always cause formatting confusion.

Please forgive me for obsessive-compulsive disorder and poor English.
Thanks.