### PR TITLE
Drop regex-tool

### DIFF
--- a/lisp/init-misc.el
+++ b/lisp/init-misc.el
@@ -34,10 +34,6 @@
          "\\|^Please enter your password for user .*?:\\s *\\'")))
 
 
-
-(when (maybe-require-package 'regex-tool)
-  (setq-default regex-tool-backend 'perl))
-
 (after-load 're-builder
   ;; Support a slightly more idiomatic quit binding in re-builder
   (define-key reb-mode-map (kbd "C-c C-k") 'reb-quit))


### PR DESCRIPTION
Hello

It is outdated and is no longer maintained (see jwiegley/regex-tool#6).

Thanks.