### PR TITLE
 Add `.cache/` to .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ site-lisp/package/
 /rake.cache
 /plantuml.jar
 /magithub
+.cache/


### PR DESCRIPTION
I think we don't need `.cache/` directory in repo. It will be generated automatically.

![image](https://user-images.githubusercontent.com/8858472/50543697-fb385700-0c19-11e9-84ca-63939dab0728.png)
