### PR TITLE
Improve dash-at-point installation

### DIFF
--- a/lisp/init-dash.el
+++ b/lisp/init-dash.el
@@ -2,6 +2,7 @@
 
 (defun sanityinc/dash-installed-p ()
   "Return t if Dash is installed on this machine, or nil otherwise."
+  (message "Checking whether Dash is installed")
   (let ((lsregister "/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister"))
     (and (file-executable-p lsregister)
          (not (string-equal
@@ -9,12 +10,8 @@
                (shell-command-to-string
                 (concat lsregister " -dump|grep com.kapeli.dash")))))))
 
-(when (and *is-a-mac* (not (package-installed-p 'dash-at-point)))
-  (message "Checking whether Dash is installed")
-  (when (sanityinc/dash-installed-p)
-    (require-package 'dash-at-point)))
-
-(when (package-installed-p 'dash-at-point)
-  (global-set-key (kbd "C-c D") 'dash-at-point))
+(when (and *is-a-mac* (sanityinc/dash-installed-p))
+  (when (maybe-require-package 'dash-at-point)
+    (global-set-key (kbd "C-c D") 'dash-at-point)))
 
 (provide 'init-dash)


### PR DESCRIPTION
Hello:

I always feel that your current code has executed an unnecessary `(package-installed-p 'dash-at-point)`.
Because 'require-package` or `maybe-require-package` will execute `package-installed-p` first anyway.

Thank you.