### PR TITLE
No longer autoload "enable-paredit-mode" manually

### DIFF
--- a/lisp/init-paredit.el
+++ b/lisp/init-paredit.el
@@ -3,7 +3,6 @@
 ;;; Code:
 
 (require-package 'paredit)
-(autoload 'enable-paredit-mode "paredit")
 
 (defun maybe-map-paredit-newline ()
   (unless (or (memq major-mode '(inferior-emacs-lisp-mode cider-repl-mode))


### PR DESCRIPTION
Hello 

See https://mumble.net/~campbell/emacs/paredit.el
```elisp
...
;;;###autoload
(defun enable-paredit-mode ()
  "Turn on pseudo-structural editing of Lisp code."
  (interactive)
  (paredit-mode +1))
...
```
Thank you.