### PR TITLE
Call exec-path-from-shell-initialize when daemonp and unixy.

### DIFF
--- a/lisp/init-exec-path.el
+++ b/lisp/init-exec-path.el
@@ -9,7 +9,10 @@
     (add-to-list 'exec-path-from-shell-variables var)))
 
 
-(when (memq window-system '(mac ns x))
+(when (or (memq window-system '(mac ns x))
+          (and (daemonp)
+               (memq system-type '(gnu gnu/linux gnu/kfreebsd darwin aix
+                                       berkeley-unix hpux usg-unix-v))))
   (setq-default exec-path-from-shell-arguments nil)
   (exec-path-from-shell-initialize))
 


### PR DESCRIPTION
Hi @purcell,

TL;DR: This pull request is to change the default behavior of init-exec-path.el, letting it call exec-path-from-shell-initialize when you activate an emacs daemon through launchers such as launchd on mac or systemd on linux.

When emacs with this emacs.d is activated through such launchers as a daemon, the value of window-system is nil and the launchers' path environment variables are likely to be different from that of your shell, resulting its exec-path to be set something way different from that of emacs called in a shell.

For example, on my mac the values are:

**When activated by launchd:** ("/usr/bin" "/bin" "/usr/sbin" "/sbin" "/usr/local/Cellar/emacs/26.1_1/libexec/emacs/26.1/x86_64-apple-darwin16.7.0") 
**When called in a shell:** ("/Users/mukuge/.pyenv/shims/" "/Users/mukuge/.pyenv/bin/" "/usr/local/bin/" "/Users/mukuge/.cargo/bin/" "/usr/local/Cellar/zplug/2.4.2/bin/" "/usr/bin/" "/bin/" "/usr/sbin/" "/sbin/" "/opt/X11/bin/" "/usr/local/Cellar/emacs/26.1_1/libexec/emacs/26.1/x86_64-apple-darwin16.7.0/")

This is just the result of everything working correctly, but this default behavior would be inconvenient for most users who expect the exec-path value should be synchronized at startup with the shell's initial path value thanks to exec-path-from-shell.

Please don't hesitate to reject this pull request if you think changing the default behavior is not a good  idea. In the end, I can put it in my init-preload-local.el.

Thanks a million for sharing your emacs.d. I use it everyday.

