### PR TITLE
Enable bug-reference-github correctly

### DIFF
--- a/lisp/init-github.el
+++ b/lisp/init-github.el
@@ -5,7 +5,9 @@
 (require 'init-git)
 
 (maybe-require-package 'yagist)
+
 (require-package 'bug-reference-github)
+(add-hook 'prog-mode-hook 'bug-reference-github-set-url-format)
 (add-hook 'prog-mode-hook 'bug-reference-prog-mode)
 
 (maybe-require-package 'github-clone)


### PR DESCRIPTION
Hello:

I found that bug-reference-github doesn't seem to be enabled.

Thank you.