### PR TITLE
Bind magit-dispatch instead of magit-dispatch-popup to "C-x M-g"

### DIFF
--- a/lisp/init-git.el
+++ b/lisp/init-git.el
@@ -22,7 +22,7 @@
   ;; quickly open magit on any one of your projects.
   (global-set-key [(meta f12)] 'magit-status)
   (global-set-key (kbd "C-x g") 'magit-status)
-  (global-set-key (kbd "C-x M-g") 'magit-dispatch-popup)
+  (global-set-key (kbd "C-x M-g") 'magit-dispatch)
 
   (defun sanityinc/magit-or-vc-log-file (&optional prompt)
     (interactive "P")


### PR DESCRIPTION
Hello:

Since magit switched to `transient`, `magit-dispath-popup` has been removed and it has no "obsolete function alias".

Thanks.