### PR TITLE
Remove redundant coding system configuration

### DIFF
--- a/lisp/init-locales.el
+++ b/lisp/init-locales.el
@@ -16,8 +16,6 @@
 (when (or window-system (sanityinc/locale-is-utf8-p))
   (set-language-environment 'utf-8)
   (setq locale-coding-system 'utf-8)
-  (set-default-coding-systems 'utf-8)
-  (set-terminal-coding-system 'utf-8)
   (set-selection-coding-system (if (eq system-type 'windows-nt) 'utf-16-le 'utf-8))
   (prefer-coding-system 'utf-8))
 


### PR DESCRIPTION
Hello:

`(prefer-coding-system)` can handle these. So those removed are superfluous.

Thanks.