### PR TITLE
Test against Emacs 26.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - EVM_EMACS=emacs-25.2-travis
   - EVM_EMACS=emacs-25.3-travis
   - EVM_EMACS=emacs-26.1-travis
+  - EVM_EMACS=emacs-26.2-travis
   #- EVM_EMACS=emacs-git-snapshot-travis
 
 matrix:


### PR DESCRIPTION
EVM now supports Emacs 26.2, see https://github.com/rejeep/evm/issues/118