### PR TITLE
Load extra configuration from optional annex directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,17 @@ customize-themes</kbd> etc. and/or create a file
 If you need initialisation code which executes earlier in the startup process,
 you can also create an `~/.emacs.d/lisp/init-preload-local.el` file.
 
-If you plan to customize things more extensively, you should probably
+If you plan to customize things more extensively, you could
 just fork the repo and hack away at the config to make it your own!
 Remember to regularly merge in changes from this repo, so that your
 config remains compatible with the latest package and Emacs versions.
+
+A better alternative if your customizations are simply additions, is use the
+annex mechanism.  Put all your changes in `~/.emacs.d.annex/init-annex.el`.
+Your annex configuration may be split into multiple files in that directory, but
+it is recommended that all files are given a prefix of `init-annex-`, to avoid
+name clashes with the main configuration.  This approach makes it easier to
+track upstream changes.
 
 *Please note that I cannot provide support for customised versions of
 this configuration.*

--- a/init.el
+++ b/init.el
@@ -176,6 +176,13 @@
 ;;----------------------------------------------------------------------------
 (require 'init-local nil t)
 
+;;----------------------------------------------------------------------------
+;; Alternatively, allow users to provide a more extensive optional annex.
+;;----------------------------------------------------------------------------
+(let ((annex-dir (expand-file-name "~/.emacs.d.annex")))
+  (if (file-directory-p annex-dir)
+      (progn (add-to-list 'load-path annex-dir)
+             (require 'init-annex nil t))))
 
 
 (provide 'init)


### PR DESCRIPTION
This is an approach I have come to after some frustration in trying to maintain my own customisations within the `~/.emacs.d` repo.  Since pretty much all of my customisations are additions (e.g. programming language modes that are unsupported in the base config), I was after an easy way to add significant amounts of config, but enable easy tracking of upstream changes.  After ongoing games with `git rebase`, I had a rethink about a simpler approach.

The approach here is to support a separate `~/.emacs.d.annex` directory, and load it via `init-annex`.  It is harmless if these don't exist.

This provides a similar but more powerful hook than the existing `init-local` mechanism.

As an example, my own annex is at https://github.com/tesujimath/emacs.d.annex

If this PR is accepted, I will obviously change the comment there.  Until then, use of an annex requires a customised `init-local`, and I am trying to move away from any in-repo changes at all.