### PR TITLE
Fix js2-mode error when loading coffee-mode on emacs 25.2

### DIFF
--- a/lisp/init-javascript.el
+++ b/lisp/init-javascript.el
@@ -54,7 +54,7 @@
 ;;; Coffeescript
 
 (after-load 'coffee-mode
-  (setq-default coffee-js-mode js2-mode
+  (setq-default coffee-js-mode 'js2-mode
                 coffee-tab-width js-indent-level))
 
 (when (fboundp 'coffee-mode)


### PR DESCRIPTION
Attempting to load coffee-mode causes the error
`File mode specification error: (void-variable js2-mode)`.

If js2-mode was already enabled in the buffer, the error is instead
`Symbol's value as variable is void: js2-mode`

This problem is resolved by quoting `js2-mode`.