### PR TITLE
Builtins, multiple versions, and new installs

### DIFF
--- a/lisp/init-elpa.el
+++ b/lisp/init-elpa.el
@@ -34,13 +34,27 @@ If NO-REFRESH is non-nil, the available package lists will not be
 re-downloaded in order to locate PACKAGE."
   (or (package-installed-p package min-version)
       (let* ((known (cdr (assoc package package-archive-contents)))
-             (versions (mapcar #'package-desc-version known)))
-        (if (cl-some (lambda (v) (version-list-<= min-version v)) versions)
-            (package-install package)
+             (matches (seq-filter
+                       (lambda (p-d)
+                         (or (not min-version)
+                             (version-list-<= min-version (package-desc-version p-d))))
+                       known))
+             (best (seq-reduce
+                    (lambda (a b)
+                      (if (and a b)
+                          (if (version-list-<= (package-desc-version a) (package-desc-version b))
+                              b
+                            a)
+                        (or a b)))
+		    matches
+                    nil)))
+        (if best
+            (package-install best)
           (if no-refresh
               (error "No version of %s >= %S is available" package min-version)
             (package-refresh-contents)
-            (require-package package min-version t))))))
+            (require-package package min-version t)))
+        (package-installed-p package min-version))))
 
 (defun maybe-require-package (package &optional min-version no-refresh)
   "Try to install PACKAGE, and return non-nil if successful.


### PR DESCRIPTION
Trying to (require-package 'project '(0 5 3)) doesn't work, because 'project is builtin, and even though the version isn't sufficient, (package-install 'project) will just choose the builtin. The package-desc needs to be passed in. Along with that, I try to select the highest version.

The return value from (package-install package) is sometimes nil if the package was not previously downloaded, so I've changed the return value of (require-package) to be whether the package is actually installed. (I tested this by rm -rf the package-user-dir and then starting up emacs.)