### PR TITLE
Add "-" arg to make black reformatter read from stdin

### DIFF
--- a/lisp/init-python.el
+++ b/lisp/init-python.el
@@ -37,7 +37,7 @@
   (add-to-list 'auto-mode-alist '("poetry\\.lock\\'" . toml-mode)))
 
 (when (maybe-require-package 'reformatter)
-  (reformatter-define black :program "black"))
+  (reformatter-define black :program "black" :args '("-")))
 
 (provide 'init-python)
 ;;; init-python.el ends here


### PR DESCRIPTION
Currently, it complains that "No Path provided. Nothing to do 😴". Apparently black doesn't read from stdin even if no file path is provided.