### PR TITLE
Rename consult-recent-file filters

### DIFF
--- a/lisp/init-minibuffer.el
+++ b/lisp/init-minibuffer.el
@@ -28,7 +28,7 @@
      consult-ripgrep
      consult-git-grep consult-grep
      consult-bookmark consult-recent-file consult-xref
-     consult--source-file consult--source-project-file consult--source-bookmark)
+     consult--source-recent-file consult--source-project-recent-file consult--source-bookmark)
 
     (when (maybe-require-package 'projectile)
       (setq-default consult-project-root-function 'projectile-project-root))


### PR DESCRIPTION
Seems like `consult--source-recent-file` and `consult--source-project-recent-file` are renamed to `consult--source-recent-file` and `consult--source-project-recent-file` in commit [69bc425](https://github.com/minad/consult/commit/69bc425c59414ece0a49dfa8e3f2d9759a13748c).