### PR TITLE
Purescript environment with eglot

### DIFF
--- a/lisp/init-purescript.el
+++ b/lisp/init-purescript.el
@@ -40,7 +40,11 @@
     (with-eval-after-load 'psci
       (advice-add 'psci :around (lambda (oldfun &rest args)
                                   (let ((psci/purs-path (or (executable-find "purs")
-                                                            psci/purs-path)))
+                                                            psci/purs-path))
+                                        (psci/psc-package-path (or (executable-find "psc-package")
+                                                                   psci/psc-package-path))
+                                        (psci/spago-path (or (executable-find "spago")
+                                                             psci/spago-path)))
                                     (apply oldfun args)))))))
 
 (provide 'init-purescript)

--- a/lisp/init-purescript.el
+++ b/lisp/init-purescript.el
@@ -18,39 +18,18 @@
     (reformatter-define purty
       :program "purty" :lighter " purty"))
 
-  (when (maybe-require-package 'psc-ide)
-    (add-hook 'purescript-mode-hook 'psc-ide-mode)
-    (add-hook 'psc-ide-mode-hook
-              (lambda ()
-                (setq-local flycheck-check-syntax-automatically '(save mode-enabled))))
-
-    (defun psc-ide-foreign-js-after-save-handler ()
-      "Call `psc-ide-rebuild' in any neighbouring purescript file buffer, if `psc-ide-rebuild-on-save' is set.
-This is a little magical because it only works if the
-corresponding .purs file is open."
-      (let ((js-path (buffer-file-name)))
-        (when js-path
-          (let* ((purs-path (concat (file-name-sans-extension js-path) ".purs"))
-                 (purs-buf (get-file-buffer purs-path)))
-            (when purs-buf
-              (with-current-buffer purs-buf
-                (when psc-ide-mode
-                  (cond
-                   (psc-ide-rebuild-on-save
-                    (message "Triggering rebuild of %s" purs-path)
-                    (psc-ide-rebuild))
-                   (flycheck-mode
-                    (message "Flychecking %s" purs-path)
-                    (flycheck-buffer))))))))))
-
-    (define-minor-mode psc-ide-foreign-js-mode
-      "Rebuild corresponding purescript file."
-      :init-value nil
-      :lighter " PursJS"
-      :global nil
-      (if psc-ide-foreign-js-mode
-          (add-hook 'after-save-hook 'psc-ide-foreign-js-after-save-handler nil t)
-        (remove-hook 'after-save-hook 'psc-ide-foreign-js-after-save-handler t))))
+  (when (maybe-require-package 'eglot)
+    (with-eval-after-load 'purescript-mode
+      (require 'eglot)  ;; to bring `eglot-server-programs' in scope
+      ;; hook must run only after add-node-modules-path
+      (add-hook 'purescript-mode-hook
+                (lambda ()
+                  (let ((path (concat "PATH=" (mapconcat #'identity exec-path path-separator)))
+                        (ps-lsp-cmd (cdr (assoc 'purescript-mode eglot-server-programs))))
+                    (make-local-variable 'eglot-server-programs)
+                    (push `(purescript-mode . ,(append '("env") (list path) ps-lsp-cmd)) eglot-server-programs)
+                    (eglot-ensure)))
+                t)))
 
   (when (maybe-require-package 'psci)
     (add-hook 'purescript-mode-hook 'inferior-psci-mode))


### PR DESCRIPTION
Hi,

As you're aware, [flymake in purescript-mode isn't working](https://github.com/purcell/flymake-flycheck/issues/1) at present. (I tried digging into it, and it appears that for some reason psc-ide refuses to appear in the list of enabled checkers in flycheck, but that's as far as I got.)

Anyway, I had some use for purescript, so I went ahead and tried out purescript-language-server on eglot. The good news is, it pretty much works out of the box (i.e. calling `eglot-ensure` alone is enough), if you install the language server + purs + spago (not sure about bower) globally.

Personally, I hate installing anything globally, so there's just a few lines of code in this PR to make the language server find executables in the local project `node_modules` folder (and falls back to the usual behaviour if that fails). It works well for me so far, and maybe someone else might find it useful.

Thanks,

Arthur