### PR TITLE
[minibuffer] Fix "Invalid preview key" message in minibuffer

### DIFF
--- a/lisp/init-minibuffer.el
+++ b/lisp/init-minibuffer.el
@@ -14,7 +14,7 @@
   (when (maybe-require-package 'consult)
     (defmacro sanityinc/no-consult-preview (&rest cmds)
       `(with-eval-after-load 'consult
-         (consult-customize ,@cmds :preview-key (kbd "M-P"))))
+         (consult-customize ,@cmds :preview-key "M-P")))
 
     (sanityinc/no-consult-preview
      consult-ripgrep


### PR DESCRIPTION
The consult-customize function will now report a message when using (kbd ...) as a value for the :preview-key.

See https://github.com/doomemacs/doomemacs/issues/7064.