### PR TITLE
Remove all form feed (^L) characters

### DIFF
--- a/init.el
+++ b/init.el
@@ -21,7 +21,7 @@
 (defconst *spell-check-support-enabled* nil) ;; Enable with t if you prefer
 (defconst *is-a-mac* (eq system-type 'darwin))
 
-
+
 ;; Adjust garbage collection thresholds during startup, and thereafter
 
 (let ((normal-gc-cons-threshold (* 20 1024 1024))
@@ -30,7 +30,7 @@
   (add-hook 'emacs-startup-hook
             (lambda () (setq gc-cons-threshold normal-gc-cons-threshold))))
 
-
+
 ;; Bootstrap config
 
 
@@ -41,7 +41,7 @@
 (require 'init-elpa)      ;; Machinery for installing required packages
 (require 'init-exec-path) ;; Set up $PATH
 
-
+
 ;; Allow users to provide an optional "init-preload-local.el"
 (require 'init-preload-local nil t)
 
@@ -151,7 +151,7 @@
 
 (require 'init-direnv)
 
-
+
 
 ;; Allow access from emacsclient
 (add-hook 'after-init-hook

--- a/lisp/init-benchmarking.el
+++ b/lisp/init-benchmarking.el
@@ -24,7 +24,7 @@ LOAD-DURATION is the time taken in milliseconds to load FEATURE.")
 
 (advice-add 'require :around 'sanityinc/require-times-wrapper)
 
-
+
 (define-derived-mode sanityinc/require-times-mode tabulated-list-mode "Require-Times"
   "Show times taken to `require' packages."
   (setq tabulated-list-format
@@ -64,7 +64,7 @@ LOAD-DURATION is the time taken in milliseconds to load FEATURE.")
     (tabulated-list-revert)
     (display-buffer (current-buffer))))
 
-
+
 
 
 (defun sanityinc/show-init-time ()

--- a/lisp/init-css.el
+++ b/lisp/init-css.el
@@ -7,7 +7,7 @@
   (dolist (hook '(css-mode-hook html-mode-hook sass-mode-hook))
     (add-hook hook 'rainbow-mode)))
 
-
+
 ;;; Embedding in html
 (require-package 'mmm-mode)
 (with-eval-after-load 'mmm-vars
@@ -37,7 +37,7 @@
 
 
 
-
+
 ;;; SASS and SCSS
 (require-package 'sass-mode)
 (unless (fboundp 'scss-mode)
@@ -46,7 +46,7 @@
 (setq-default scss-compile-at-save nil)
 
 
-
+
 ;;; LESS
 (unless (fboundp 'less-css-mode)
   ;; Prefer the scss-mode built into Emacs
@@ -55,12 +55,12 @@
   (add-hook 'less-css-mode-hook 'skewer-less-mode))
 
 
-
+
 ;; Skewer CSS
 (when (maybe-require-package 'skewer-mode)
   (add-hook 'css-mode-hook 'skewer-css-mode))
 
-
+
 ;;; Use eldoc for syntax hints
 (require-package 'css-eldoc)
 (autoload 'turn-on-css-eldoc "css-eldoc")

--- a/lisp/init-editing-utils.el
+++ b/lisp/init-editing-utils.el
@@ -10,7 +10,7 @@
 
 (maybe-require-package 'list-unicode-display)
 
-
+
 ;;; Some basic preferences
 
 (setq-default
@@ -44,7 +44,7 @@
 (add-hook 'after-init-hook 'transient-mark-mode)
 
 
-
+
 ;; Huge files
 
 (when (fboundp 'so-long-enable)
@@ -60,13 +60,13 @@
       (error "File does not exist: %s" file))
     (vlf file)))
 
-
+
 ;;; A simple visible bell which works in all terminal types
 (require-package 'mode-line-bell)
 (add-hook 'after-init-hook 'mode-line-bell-mode)
 
 
-
+
 ;;; Newline behaviour
 
 (global-set-key (kbd "RET") 'newline-and-indent)
@@ -78,30 +78,30 @@
 
 (global-set-key (kbd "S-<return>") 'sanityinc/newline-at-end-of-line)
 
-
+
 
 (with-eval-after-load 'subword
   (diminish 'subword-mode))
 
-
+
 
 (when (fboundp 'display-line-numbers-mode)
   (setq-default display-line-numbers-width 3)
   (add-hook 'prog-mode-hook 'display-line-numbers-mode))
 
-
+
 
 (when (boundp 'display-fill-column-indicator)
   (setq-default indicate-buffer-boundaries 'left)
   (setq-default display-fill-column-indicator-character ?\u254e)
   (add-hook 'prog-mode-hook 'display-fill-column-indicator-mode))
 
-
+
 
 (when (require-package 'rainbow-delimiters)
   (add-hook 'prog-mode-hook 'rainbow-delimiters-mode))
 
-
+
 (when (maybe-require-package 'symbol-overlay)
   (dolist (hook '(prog-mode-hook html-mode-hook yaml-mode-hook conf-mode-hook))
     (add-hook hook 'symbol-overlay-mode))
@@ -112,12 +112,12 @@
     (define-key symbol-overlay-mode-map (kbd "M-n") 'symbol-overlay-jump-next)
     (define-key symbol-overlay-mode-map (kbd "M-p") 'symbol-overlay-jump-prev)))
 
-
+
 ;;; Zap *up* to char is a handy pair for zap-to-char
 (global-set-key (kbd "M-Z") 'zap-up-to-char)
 
 
-
+
 (require-package 'browse-kill-ring)
 (setq browse-kill-ring-separator "\f")
 (global-set-key (kbd "M-Y") 'browse-kill-ring)
@@ -142,7 +142,7 @@
 (add-hook 'after-init-hook 'show-paren-mode)
 
 
-
+
 ;;; Handy key bindings
 
 (global-set-key (kbd "C-.") 'set-mark-command)
@@ -172,7 +172,7 @@
 (global-set-key (kbd "C-M-<backspace>") 'kill-back-to-indentation)
 
 
-
+
 ;;; Page break lines
 
 (when (maybe-require-package 'page-break-lines)
@@ -181,7 +181,7 @@
     (diminish 'page-break-lines-mode)))
 
 
-
+
 ;; Shift lines up and down with M-up and M-down. When paredit is enabled,
 ;; it will use those keybindings. For this reason, you might prefer to
 ;; use M-S-up and M-S-down, which will work even in lisp modes.
@@ -195,7 +195,7 @@
 (global-set-key (kbd "C-c d") 'move-dup-duplicate-down)
 (global-set-key (kbd "C-c u") 'move-dup-duplicate-up)
 
-
+
 ;;; Fix backward-up-list to understand quotes, see http://bit.ly/h7mdIL
 
 (defun sanityinc/backward-up-sexp (arg)
@@ -210,14 +210,14 @@
 (global-set-key [remap backward-up-list] 'sanityinc/backward-up-sexp) ; C-M-u, C-M-up
 
 
-
+
 ;;; Cut/copy the current line if no region is active
 (require-package 'whole-line-or-region)
 (add-hook 'after-init-hook 'whole-line-or-region-global-mode)
 (with-eval-after-load 'whole-line-or-region
   (diminish 'whole-line-or-region-local-mode))
 
-
+
 
 (defun sanityinc/open-line-with-reindent (n)
   "A version of `open-line' which reindents the start and end positions.
@@ -249,11 +249,11 @@ With arg N, insert N newlines."
 (global-set-key (kbd "C-o") 'sanityinc/open-line-with-reindent)
 
 
-
+
 ;; M-^ is inconvenient, so also bind M-j
 (global-set-key (kbd "M-j") 'join-line)
 
-
+
 ;; Random line sorting
 (defun sanityinc/sort-lines-random (beg end)
   "Sort lines in region from BEG to END randomly."
@@ -267,19 +267,19 @@ With arg N, insert N newlines."
         (sort-subr nil 'forward-line 'end-of-line nil nil
                    (lambda (s1 s2) (eq (random 2) 0)))))))
 
-
+
 
 (require-package 'highlight-escape-sequences)
 (add-hook 'after-init-hook 'hes-mode)
 
-
+
 (require-package 'which-key)
 (add-hook 'after-init-hook 'which-key-mode)
 (setq-default which-key-idle-delay 1.5)
 (with-eval-after-load 'which-key
   (diminish 'which-key-mode))
 
-
+
 (defun sanityinc/disable-features-during-macro-call (orig &rest args)
   "When running a macro, disable features that might be expensive.
 ORIG is the advised function, which is called with its ARGS."

--- a/lisp/init-elpa.el
+++ b/lisp/init-elpa.el
@@ -5,14 +5,14 @@
 (require 'package)
 (require 'cl-lib)
 
-
+
 ;;; Install into separate package dirs for each Emacs version, to prevent bytecode incompatibility
 (setq package-user-dir
       (expand-file-name (format "elpa-%s.%s" emacs-major-version emacs-minor-version)
                         user-emacs-directory))
 
 
-
+
 ;;; Standard package repositories
 
 (add-to-list 'package-archives '( "melpa" . "https://melpa.org/packages/") t)
@@ -20,12 +20,12 @@
 ;;(add-to-list 'package-archives (cons "melpa-mirror" (concat proto "://www.mirrorservice.org/sites/melpa.org/packages/")) t)
 
 
-
+
 ;; Work-around for https://debbugs.gnu.org/cgi/bugreport.cgi?bug=34341
 (when (and (version< emacs-version "26.3") (boundp 'libgnutls-version) (>= libgnutls-version 30604))
   (setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3"))
 
-
+
 ;;; On-demand installation of packages
 
 (defun require-package (package &optional min-version no-refresh)
@@ -59,13 +59,13 @@ locate PACKAGE."
      (message "Couldn't install optional package `%s': %S" package err)
      nil)))
 
-
+
 ;;; Fire up package.el
 
 (setq package-enable-at-startup nil)
 (package-initialize)
 
-
+
 ;; package.el updates the saved version of package-selected-packages correctly only
 ;; after custom-file has been loaded, which is a bug. We work around this by adding
 ;; the required packages to package-selected-packages after startup is complete.
@@ -92,15 +92,15 @@ advice for `require-package', to which ARGS are passed."
               (package--save-selected-packages
                (seq-uniq (append sanityinc/required-packages package-selected-packages))))))
 
-
+
 (require-package 'fullframe)
 (fullframe list-packages quit-window)
 
-
+
 (let ((package-check-signature nil))
   (require-package 'gnu-elpa-keyring-update))
 
-
+
 (defun sanityinc/set-tabulated-list-column-width (col-name width)
   "Set any column with name COL-NAME to the given WIDTH."
   (when (> width (length col-name))

--- a/lisp/init-git.el
+++ b/lisp/init-git.el
@@ -48,19 +48,19 @@
 (when (maybe-require-package 'git-commit)
   (add-hook 'git-commit-mode-hook 'goto-address-mode))
 
-
+
 (when *is-a-mac*
   (with-eval-after-load 'magit
     (add-hook 'magit-mode-hook (lambda () (local-unset-key [(meta h)])))))
 
 
-
+
 ;; Convenient binding for vc-git-grep
 (with-eval-after-load 'vc
   (define-key vc-prefix-map (kbd "f") 'vc-git-grep))
 
 
-
+
 ;;; git-svn support
 
 ;; (when (maybe-require-package 'magit-svn)

--- a/lisp/init-gui-frames.el
+++ b/lisp/init-gui-frames.el
@@ -2,7 +2,7 @@
 ;;; Commentary:
 ;;; Code:
 
-
+
 ;; Stop C-z from minimizing windows under OS X
 
 (defun sanityinc/maybe-suspend-frame ()
@@ -13,7 +13,7 @@
 (global-set-key (kbd "C-z") 'sanityinc/maybe-suspend-frame)
 
 
-
+
 ;; Suppress GUI features
 
 (setq use-file-dialog nil)
@@ -21,7 +21,7 @@
 (setq inhibit-startup-screen t)
 
 
-
+
 ;; Window size and features
 
 (setq-default
@@ -78,14 +78,14 @@
           (lambda ()
             (setq line-spacing 0)))
 
-
+
 ;; Change global font size easily
 
 (require-package 'default-text-scale)
 (add-hook 'after-init-hook 'default-text-scale-mode)
 
 
-
+
 (require-package 'disable-mouse)
 
 

--- a/lisp/init-haskell.el
+++ b/lisp/init-haskell.el
@@ -38,7 +38,7 @@
     (add-to-list 'page-break-lines-modes 'haskell-mode)))
 
 
-
+
 (maybe-require-package 'dhall-mode)
 
 

--- a/lisp/init-javascript.el
+++ b/lisp/init-javascript.el
@@ -7,7 +7,7 @@
 (maybe-require-package 'typescript-mode)
 (maybe-require-package 'prettier-js)
 
-
+
 ;;; Basic js-mode setup
 
 (add-to-list 'auto-mode-alist '("\\.\\(js\\|es6\\)\\(\\.erb\\)?\\'" . js-mode))
@@ -19,7 +19,7 @@
 (setq-default js-indent-level 2)
 
 
-
+
 ;; js2-mode
 
 ;; Change some defaults: customize them to override
@@ -47,7 +47,7 @@
   (sanityinc/major-mode-lighter 'js2-mode "JS2")
   (sanityinc/major-mode-lighter 'js2-jsx-mode "JSX2"))
 
-
+
 
 (when (and (or (executable-find "rg") (executable-find "ag"))
            (maybe-require-package 'xref-js2))
@@ -63,7 +63,7 @@
     (add-hook 'js2-mode-hook 'sanityinc/enable-xref-js2)))
 
 
-
+
 ;;; Coffeescript
 
 (when (maybe-require-package 'coffee-mode)
@@ -73,7 +73,7 @@
   (when (fboundp 'coffee-mode)
     (add-to-list 'auto-mode-alist '("\\.coffee\\.erb\\'" . coffee-mode))))
 
-
+
 ;; Run and interact with an inferior JS via js-comint.el
 
 (when (maybe-require-package 'js-comint)
@@ -90,7 +90,7 @@
   (dolist (hook '(js2-mode-hook js-mode-hook))
     (add-hook hook 'inferior-js-keys-mode)))
 
-
+
 ;; Alternatively, use skewer-mode
 
 (when (maybe-require-package 'skewer-mode)
@@ -99,7 +99,7 @@
               (lambda () (inferior-js-keys-mode -1)))))
 
 
-
+
 (when (maybe-require-package 'add-node-modules-path)
   (dolist (mode '(typescript-mode js-mode js2-mode coffee-mode))
     (add-hook (derived-mode-hook-name mode) 'add-node-modules-path)))

--- a/lisp/init-lisp.el
+++ b/lisp/init-lisp.el
@@ -27,7 +27,7 @@
       (goto-char (point-max))
       (insert ";;; " fname " ends here\n"))))
 
-
+
 ;; Make C-x C-e run 'eval-region if the region is active
 
 (defun sanityinc/eval-last-sexp-or-region (prefix)
@@ -54,7 +54,7 @@
       (view-mode 1))))
 (advice-add 'pp-display-expression :after 'sanityinc/make-read-only)
 
-
+
 
 (defun sanityinc/load-this-file ()
   "Load the current file or buffer.
@@ -74,7 +74,7 @@ there is no current file, eval the current buffer."
 (with-eval-after-load 'lisp-mode
   (define-key emacs-lisp-mode-map (kbd "C-c C-l") 'sanityinc/load-this-file))
 
-
+
 
 (defun sanityinc/maybe-set-bundled-elisp-readonly ()
   "If this elisp appears to be part of Emacs, then disallow editing."
@@ -85,7 +85,7 @@ there is no current file, eval the current buffer."
 
 (add-hook 'emacs-lisp-mode-hook 'sanityinc/maybe-set-bundled-elisp-readonly)
 
-
+
 ;; Use C-c C-z to toggle between elisp files and an ielm session
 ;; I might generalise this to ruby etc., or even just adopt the repl-toggle package.
 
@@ -114,7 +114,7 @@ there is no current file, eval the current buffer."
 (with-eval-after-load 'ielm
   (define-key ielm-map (kbd "C-c C-z") 'sanityinc/repl-switch-back))
 
-
+
 ;; Hippie-expand
 
 (defun set-up-hippie-expand-for-elisp ()
@@ -124,7 +124,7 @@ there is no current file, eval the current buffer."
   (add-to-list 'hippie-expand-try-functions-list 'try-complete-lisp-symbol-partially t))
 
 
-
+
 ;; Automatic byte compilation
 
 (when (maybe-require-package 'auto-compile)
@@ -132,17 +132,17 @@ there is no current file, eval the current buffer."
   (add-hook 'after-init-hook 'auto-compile-on-save-mode)
   (add-hook 'after-init-hook 'auto-compile-on-load-mode))
 
-
+
 ;; Load .el if newer than corresponding .elc
 
 (setq load-prefer-newer t)
 
-
+
 
 (require-package 'immortal-scratch)
 (add-hook 'after-init-hook 'immortal-scratch-mode)
 
-
+
 ;;; Support byte-compilation in a sub-process, as
 ;;; required by highlight-cl
 
@@ -159,7 +159,7 @@ there is no current file, eval the current buffer."
        " ")))))
 
 
-
+
 ;; Enable desired features for all lisp modes
 
 (defun sanityinc/enable-check-parens-on-save ()
@@ -207,7 +207,7 @@ there is no current file, eval the current buffer."
 (add-to-list 'auto-mode-alist '("archive-contents\\'" . emacs-lisp-mode))
 
 
-
+
 ;; Delete .elc files when reverting the .el from VC or magit
 
 ;; When .el files are open, we can intercept when they are modified
@@ -241,18 +241,18 @@ there is no current file, eval the current buffer."
 (advice-add 'vc-revert-buffer-internal :around 'sanityinc/reverting)
 
 
-
+
 (require-package 'macrostep)
 
 (with-eval-after-load 'lisp-mode
   (define-key emacs-lisp-mode-map (kbd "C-c x") 'macrostep-expand))
 
-
+
 
 ;; A quick way to jump to the definition of a function given its key binding
 (global-set-key (kbd "C-h K") 'find-function-on-key)
 
-
+
 
 ;; Extras for theme editing
 (when (maybe-require-package 'rainbow-mode)
@@ -264,28 +264,28 @@ there is no current file, eval the current buffer."
   (with-eval-after-load 'rainbow-mode
     (diminish 'rainbow-mode)))
 
-
+
 
 (when (maybe-require-package 'highlight-quoted)
   (add-hook 'emacs-lisp-mode-hook 'highlight-quoted-mode))
 
-
+
 (when (maybe-require-package 'package-lint-flymake)
   (add-hook 'emacs-lisp-mode-hook #'package-lint-flymake-setup))
 
 
-
+
 ;; ERT
 (with-eval-after-load 'ert
   (define-key ert-results-mode-map (kbd "g") 'ert-results-rerun-all-tests))
 
-
+
 (maybe-require-package 'cl-libify)
 
-
+
 (maybe-require-package 'flycheck-relint)
 
-
+
 
 (maybe-require-package 'cask-mode)
 

--- a/lisp/init-misc.el
+++ b/lisp/init-misc.el
@@ -2,7 +2,7 @@
 ;;; Commentary:
 ;;; Code:
 
-
+
 ;; Misc config - yet to be placed in separate files
 
 (add-auto-mode 'tcl-mode "^Portfile\\'")

--- a/lisp/init-nxml.el
+++ b/lisp/init-nxml.el
@@ -34,7 +34,7 @@ indentation rules."
     (nxml-mode)
     (indent-region beg end)))
 
-
+
 ;; Integration with tidy for html + xml
 
 (defun sanityinc/tidy-buffer-xml (beg end)

--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -60,7 +60,7 @@
             (lambda () (add-hook 'window-configuration-change-hook 'org-agenda-align-tags nil t))))
 
 
-
+
 
 (maybe-require-package 'writeroom-mode)
 
@@ -105,7 +105,7 @@ typical word processor."
 
 
 (setq org-support-shift-select t)
-
+
 ;;; Capturing
 
 (global-set-key (kbd "C-c c") 'org-capture)
@@ -118,7 +118,7 @@ typical word processor."
         ))
 
 
-
+
 ;;; Refiling
 
 (setq org-refile-use-cache nil)
@@ -157,7 +157,7 @@ typical word processor."
 ;; Allow refile to create parent tasks with confirmation
 (setq org-refile-allow-creating-parent-nodes 'confirm)
 
-
+
 ;;; To-do settings
 
 (setq org-todo-keywords
@@ -171,7 +171,7 @@ typical word processor."
               ("PROJECT" :inherit font-lock-string-face))))
 
 
-
+
 ;;; Agenda views
 
 (setq-default org-agenda-clockreport-parameter-plist '(:link t :maxlevel 3))
@@ -263,7 +263,7 @@ typical word processor."
 
 (add-hook 'org-agenda-mode-hook 'hl-line-mode)
 
-
+
 ;;; Org clock
 
 ;; Save the running clock and all clock history when exiting Emacs, load it on startup
@@ -284,7 +284,7 @@ typical word processor."
       '(:hours "%d" :require-hours t :minutes ":%02d" :require-minutes t))
 
 
-
+
 ;;; Show the clocked-in task - if any - in the header line
 (defun sanityinc/show-org-clock-in-header-line ()
   (setq-default header-line-format '((" " org-mode-line-string " "))))
@@ -301,7 +301,7 @@ typical word processor."
   (define-key org-clock-mode-line-map [header-line mouse-1] 'org-clock-menu))
 
 
-
+
 (when (and *is-a-mac* (file-directory-p "/Applications/org-clock-statusbar.app"))
   (add-hook 'org-clock-in-hook
             (lambda () (call-process "/usr/bin/osascript" nil 0 nil "-e"
@@ -311,12 +311,12 @@ typical word processor."
                                 "tell application \"org-clock-statusbar\" to clock out"))))
 
 
-
+
 ;; TODO: warn about inconsistent items, e.g. TODO inside non-PROJECT
 ;; TODO: nested projects!
 
 
-
+
 ;;; Archiving
 
 (setq org-archive-mark-done nil)
@@ -324,7 +324,7 @@ typical word processor."
 
 
 
-
+
 
 (require-package 'org-pomodoro)
 (setq org-pomodoro-keep-killed-pomodoro-time t)

--- a/lisp/init-ruby.el
+++ b/lisp/init-ruby.el
@@ -22,13 +22,13 @@
 
 (require-package 'rspec-mode)
 
-
+
 (define-derived-mode brewfile-mode ruby-mode "Brewfile"
   "A major mode for Brewfiles, used by homebrew-bundle on MacOS.")
 
 (add-auto-mode 'brewfile-mode "Brewfile\\'")
 
-
+
 ;;; Inferior ruby
 (require-package 'inf-ruby)
 (with-eval-after-load 'inf-ruby
@@ -41,7 +41,7 @@
   (define-key inf-ruby-minor-mode-map [remap ruby-load-file] 'sanityinc/ruby-load-file))
 
 
-
+
 ;;; Ruby compilation
 (require-package 'ruby-compilation)
 
@@ -53,29 +53,29 @@
   (defalias 'rake 'ruby-compilation-rake))
 
 
-
+
 ;;; Robe
 (when (maybe-require-package 'robe)
   (with-eval-after-load 'ruby-mode
     (add-hook 'ruby-mode-hook 'robe-mode)))
 
 
-
+
 ;;; ri support
 (require-package 'yari)
 (defalias 'ri 'yari)
 
 
-
+
 (require-package 'bundler)
 
-
+
 (when (maybe-require-package 'yard-mode)
   (add-hook 'ruby-mode-hook 'yard-mode)
   (with-eval-after-load 'yard-mode
     (diminish 'yard-mode)))
 
-
+
 ;;; ERB
 (require-package 'mmm-mode)
 
@@ -105,7 +105,7 @@
   (mmm-add-mode-ext-class mode "\\.js\\.erb\\'" 'erb))
 
 
-
+
 ;; Ruby - my convention for heredocs containing SQL
 
 ;; (require-package 'mmm-mode)

--- a/lisp/init-sessions.el
+++ b/lisp/init-sessions.el
@@ -27,7 +27,7 @@
                  (abbreviate-file-name filename))))))
 (advice-add 'desktop-create-buffer :around 'sanityinc/desktop-time-buffer-create)
 
-
+
 ;; Restore histories and registers after saving
 
 (setq-default history-length 1000)

--- a/lisp/init-site-lisp.el
+++ b/lisp/init-site-lisp.el
@@ -21,7 +21,7 @@
   (push site-lisp-dir load-path)
   (sanityinc/add-subdirs-to-load-path site-lisp-dir))
 
-;;; Utilities for grabbing upstream libs
+;;; Utilities for grabbing upstream libs
 
 (defun site-lisp-dir-for (name)
   (expand-file-name (format "site-lisp/%s" name) user-emacs-directory))

--- a/lisp/init-slime.el
+++ b/lisp/init-slime.el
@@ -5,7 +5,7 @@
 (require-package 'slime)
 (push (expand-file-name "contrib" (file-name-directory (locate-library "slime"))) load-path)
 
-
+
 ;;; Lisp buffers
 
 (with-eval-after-load 'slime
@@ -14,7 +14,7 @@
   (let ((features '(slime-fancy slime-repl slime-fuzzy)))
     (slime-setup features)) )
 
-
+
 ;;; REPL
 
 (defun sanityinc/slime-repl-setup ()

--- a/lisp/init-themes.el
+++ b/lisp/init-themes.el
@@ -23,7 +23,7 @@
 (add-hook 'after-init-hook 'reapply-themes)
 
 
-
+
 ;; Toggle between light and dark
 
 (defun light ()

--- a/lisp/init-utils.el
+++ b/lisp/init-utils.el
@@ -4,7 +4,7 @@
 
 (define-obsolete-function-alias 'after-load 'with-eval-after-load "")
 
-
+
 ;; Handier way to add modes to auto-mode-alist
 (defun add-auto-mode (mode &rest patterns)
   "Add entries to `auto-mode-alist' to use `MODE' for all given file `PATTERNS'."
@@ -20,7 +20,7 @@
   (add-hook (derived-mode-hook-name mode)
             (apply-partially 'sanityinc/set-major-mode-name name)))
 
-
+
 ;; String utilities missing from core emacs
 
 (defun sanityinc/string-all-matches (regex str &optional group)
@@ -34,7 +34,7 @@
     result))
 
 
-
+
 ;; Delete the current file
 
 (defun delete-this-file ()
@@ -48,7 +48,7 @@
     (kill-this-buffer)))
 
 
-
+
 ;; Rename the current file
 
 (defun rename-this-file-and-buffer (new-name)
@@ -64,7 +64,7 @@
       (set-visited-file-name new-name)
       (rename-buffer new-name))))
 
-
+
 ;; Browse current HTML file
 
 (defun browse-current-file ()

--- a/lisp/init-whitespace.el
+++ b/lisp/init-whitespace.el
@@ -4,7 +4,7 @@
 
 (setq-default show-trailing-whitespace nil)
 
-
+
 ;;; Whitespace
 
 (defun sanityinc/show-trailing-whitespace ()

--- a/lisp/init-windows.el
+++ b/lisp/init-windows.el
@@ -11,7 +11,7 @@
 
 (add-hook 'after-init-hook 'winner-mode)
 
-
+
 ;; Make "C-x o" prompt for a target window when there are more than 2
 (require-package 'switch-window)
 (setq-default switch-window-shortcut-style 'alphabet)
@@ -19,7 +19,7 @@
 (global-set-key (kbd "C-x o") 'switch-window)
 
 
-
+
 ;; When splitting window, show (other-buffer) in the new window
 
 (defun split-window-func-with-other-buffer (split-function)
@@ -45,7 +45,7 @@
 
 (global-set-key (kbd "C-x 1") 'sanityinc/toggle-delete-other-windows)
 
-
+
 ;; Rearrange split windows
 
 (defun split-window-horizontally-instead ()
@@ -69,7 +69,7 @@
 (global-set-key (kbd "C-x |") 'split-window-horizontally-instead)
 (global-set-key (kbd "C-x _") 'split-window-vertically-instead)
 
-
+
 ;; Borrowed from http://postmomentum.ch/blog/201304/blog-on-emacs
 
 (defun sanityinc/split-window()
@@ -86,7 +86,7 @@ Call a second time to restore the original window configuration."
 (global-set-key (kbd "<f7>") 'sanityinc/split-window)
 
 
-
+
 
 (defun sanityinc/toggle-current-window-dedication ()
   "Toggle whether the current window is dedicated to its current buffer."
@@ -101,7 +101,7 @@ Call a second time to restore the original window configuration."
 (global-set-key (kbd "C-c <down>") 'sanityinc/toggle-current-window-dedication)
 
 
-
+
 
 (unless (memq window-system '(nt w32))
   (require-package 'windswap)


### PR DESCRIPTION
The diff in this pull request looks very silly, I know. I removed all the invisible [form feed characters](https://www.asciihex.com/character/control/12/0x0C/ff-form-feed).

Took a while to figure out that these characters were the root cause of the odd issues I had getting this to work on Windows properly. They caused no issues on macOS or Linux. :)

## Some visualization of the characters

![CleanShot 2023-03-11 at 20 04 55@2x](https://user-images.githubusercontent.com/13303/224504609-4d016879-7cf0-43dc-9bf1-fe1e84685a12.png)
![CleanShot 2023-03-11 at 20 05 24@2x](https://user-images.githubusercontent.com/13303/224504618-15bb58fa-7635-4cfd-9b88-1ffb0548d2a8.png)
