### PR TITLE
Fix newline behavior

### DIFF
--- a/lisp/init-editing-utils.el
+++ b/lisp/init-editing-utils.el
@@ -69,7 +69,7 @@
 
 ;;; Newline behaviour
 
-(global-set-key (kbd "RET") 'newline-and-indent)
+(global-set-key (kbd "RET") 'newline)
 (defun sanityinc/newline-at-end-of-line ()
   "Move to end of line, enter a newline, and reindent."
   (interactive)


### PR DESCRIPTION
In multiple modes, curly braces do not align correctly.

PR closes issue #792 , as per zhou1615's advice. 

Newline and indents parens and braces correctly for php-mode & clojure-mode, and assuming the rest.
Don't know where any conflicts would be.