### PR TITLE
UTF-8 support when running 'emacs -nw' in terminal

### DIFF
--- a/lisp/init-locales.el
+++ b/lisp/init-locales.el
@@ -22,5 +22,11 @@
 (unless (eq system-type 'windows-nt)
   (set-selection-coding-system 'utf-8))
 
+;;; UTF-8 support when running 'emacs -nw', inside terminal
+(set-default-coding-systems 'utf-8)
+(set-terminal-coding-system 'utf-8)
+(set-keyboard-coding-system 'utf-8)
+(setq x-select-request-type '(UTF8_STRING COMPOUND_TEXT TEXT STRING))
+
 (provide 'init-locales)
 ;;; init-locales.el ends here


### PR DESCRIPTION
Warning: I havent run any regression tests on the change, so I dont know if it causes other issues.

Verified on:
GNU Emacs 27.1, Kubuntu 22.04.3 LTS, Konsole 21.12.3