### PR TITLE
add default org-agenda-cmp-user-defined if not already defined

### DIFF
--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -176,6 +176,9 @@ typical word processor."
 
 (setq-default org-agenda-clockreport-parameter-plist '(:link t :maxlevel 3))
 
+;;; From org-mode 9.8 empty comparator will error. 
+(unless (functionp org-agenda-cmp-user-defined)
+        (setq org-agenda-cmp-user-defined (lambda (_a _b) nil)))
 
 (setq org-stuck-projects
       '("-INBOX/PROJECT" ("NEXT")))


### PR DESCRIPTION
From org-mode 9.8 onwards `org-agenda` errors out when trying to sort with an undefined custom comparator (e.g. `user-defined-up`). Previously this was silently ignored. ([ref](https://cgit.git.savannah.nongnu.org/cgit/org-mode.git/commit/lisp/org-agenda.el?id=9b5a67fd52a65301e214c59b9326951337cd1072))

This change adds a default no-op value for `org-agenda-cmp-user-defined` if it is not already set. 